### PR TITLE
Implement Prim's Algorithm for Minimum Spanning Tree

### DIFF
--- a/S) Tree/PrimsAlgorithm.cpp
+++ b/S) Tree/PrimsAlgorithm.cpp
@@ -1,0 +1,43 @@
+#include <bits/stdc++.h>
+using namespace std;
+
+const int INF = 1e9;
+
+int main() {
+    int V, E;
+    cin >> V >> E;
+    vector<vector<pair<int,int>>> adj(V); // {neighbor, weight}
+    for(int i=0;i<E;i++){
+        int u,v,w;
+        cin >> u >> v >> w;
+        adj[u].push_back({v,w});
+        adj[v].push_back({u,w});
+    }
+
+    vector<int> key(V, INF);
+    vector<int> parent(V, -1);
+    vector<bool> inMST(V, false);
+
+    key[0] = 0; // start from node 0
+
+    for(int count=0; count<V-1; count++){
+        int u = -1;
+        for(int i=0;i<V;i++)
+            if(!inMST[i] && (u==-1 || key[i]<key[u]))
+                u=i;
+
+        inMST[u] = true;
+
+        for(auto [v,w]: adj[u])
+            if(!inMST[v] && w < key[v]){
+                key[v] = w;
+                parent[v] = u;
+            }
+    }
+
+    cout << "Edges in MST:\n";
+    for(int i=1;i<V;i++)
+        cout << parent[i] << " - " << i << " \n";
+
+    return 0;
+}


### PR DESCRIPTION
Prim’s Algorithm finds a Minimum Spanning Tree (MST) of a connected, weighted, undirected graph.

Goal: Connect all vertices with minimum total edge weight without forming a cycle.

 Algorithm Steps

Start with any vertex and mark it as part of the MST.

Find the minimum weight edge connecting a vertex in MST to a vertex outside MST.

Add that edge and the new vertex to MST.

Repeat until all vertices are included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduces a command-line tool that computes a Minimum Spanning Tree (MST) for undirected weighted graphs using Prim’s algorithm.
  * Accepts input as: number of vertices (V), number of edges (E), then E lines of “u v w” for each edge.
  * Outputs the MST as edge pairs in the format “parent - child” for vertices 1 to V-1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->