### PR TITLE
odd-even linked list

### DIFF
--- a/Q) Linked List/odd-even-linkedlist.cpp
+++ b/Q) Linked List/odd-even-linkedlist.cpp
@@ -1,0 +1,74 @@
+//Reorder all odd-positioned nodes together followed by all even-positioned nodes
+
+#include <iostream>
+using namespace std;
+
+struct Node {
+    int data;
+    Node* next;
+    Node(int val) : data(val), next(nullptr) {}
+};
+
+class LinkedList {
+public:
+    Node* head;
+
+    LinkedList() : head(nullptr) {}
+
+    void insert(int val) {
+        Node* newNode = new Node(val);
+        if (!head) {
+            head = newNode;
+            return;
+        }
+        Node* temp = head;
+        while (temp->next)
+            temp = temp->next;
+        temp->next = newNode;
+    }
+
+    void oddEven() {
+        if (!head || !head->next) return;
+
+        Node* odd = head;
+        Node* even = head->next;
+        Node* evenHead = even; 
+
+        while (even && even->next) {
+            odd->next = even->next;
+            odd = odd->next;
+            even->next = odd->next;
+            even = even->next;
+        }
+
+        odd->next = evenHead; 
+    }
+
+    void print() {
+        Node* temp = head;
+        while (temp) {
+            cout << temp->data << " ";
+            temp = temp->next;
+        }
+        cout << endl;
+    }
+};
+
+int main() {
+    LinkedList ll;
+    ll.insert(1);
+    ll.insert(2);
+    ll.insert(3);
+    ll.insert(4);
+    ll.insert(5);
+
+    cout << "Original List: ";
+    ll.print();
+
+    ll.oddEven();
+
+    cout << "Odd-Even List after reordering: ";
+    ll.print();
+
+    return 0;
+}


### PR DESCRIPTION
C++ code to reorder all odd-positioned nodes together followed by all even-positioned nodes.

-Maintain two pointers:

odd → points to the first node.

even → points to the second node.

-Move odd and even pointers alternatively.

-Then, link the end of the odd list to the start of the even list.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a linked list implementation with odd-even position reordering capability. Rearranges list elements by separating odd-positioned nodes from even-positioned nodes, placing odd-positioned nodes first while preserving relative order within each group. Includes sample demonstration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->